### PR TITLE
Capistrano

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -496,6 +496,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,6 +66,19 @@ namespace :boston_library do
     end
   end
 
+  # rubocop:disable Layout/LineLength
+  desc 'Run a console command to test -rails console-'
+  task :rails_console_runner do
+    on roles(:app), in: :sequence, wait: 5 do
+      as fetch(:user) do
+        within release_path do
+          puts capture("cd #{release_path}; #{fetch(:rvm_installed)} #{fetch(:rvm_ruby_version)} do #{release_path}/bin/rails runner -e #{fetch(:stage_case)} \"puts 'rails console works'\"")
+        end
+      end
+    end
+  end
+  # rubocop:enable Layout/LineLength
+
   desc 'Copy Gemfile and Gemfile.lock to shared directory'
   task :upload_gemfile do
     on roles(:app) do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -120,6 +120,6 @@ after :'boston_library:install_bundler', :'bundler:config'
 after :'bundler:config', :'bundler:install'
 before :'deploy:cleanup', :'boston_library:upload_gemfile'
 after :'deploy:cleanup', :'boston_library:update_service_ruby'
-# after :'boston_library:update_service_ruby', :"boston_library:restart_#{fetch(:application)}_puma"
-# after :"boston_library:restart_#{fetch(:application)}_puma", :'boston_library:restart_nginx'
-after :'boston_library:update_service_ruby', :'boston_library:list_releases'
+after :'boston_library:update_service_ruby', :"boston_library:restart_#{fetch(:application)}_puma"
+after :"boston_library:restart_#{fetch(:application)}_puma", :'boston_library:restart_nginx'
+after :'boston_library:restart_nginx', :'boston_library:list_releases'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,6 +67,7 @@ namespace :boston_library do
   end
 
   # rubocop:disable Layout/LineLength
+  # rubocop:disable Rails/Output
   desc 'Run a console command to test -rails console-'
   task :rails_console_runner do
     on roles(:app), in: :sequence, wait: 5 do
@@ -78,6 +79,7 @@ namespace :boston_library do
     end
   end
   # rubocop:enable Layout/LineLength
+  # rubocop:enable Rails/Output
 
   desc 'Copy Gemfile and Gemfile.lock to shared directory'
   task :upload_gemfile do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,6 +66,20 @@ namespace :boston_library do
     end
   end
 
+
+  # rubocop:disable Layout/LineLength
+  desc 'Run a console command to test -rails console-'
+  task :rails_console_runner do
+    on roles(:app), in: :sequence, wait: 5 do
+      as fetch(:user) do
+        within release_path do
+          puts capture("cd #{release_path}; #{fetch(:rvm_installed)} #{fetch(:rvm_ruby_version)} do #{release_path}/bin/rails runner -e staging \"puts 'rails console works'\"")
+        end
+      end
+    end
+  end
+  # rubocop:enable Layout/LineLength
+
   desc 'Copy Gemfile and Gemfile.lock to shared directory'
   task :upload_gemfile do
     on roles(:app) do
@@ -87,6 +101,13 @@ namespace :boston_library do
   task :restart_nginx do
     on roles(:app), in: :sequence, wait: 5 do
       execute 'sudo /bin/systemctl reload nginx.service'
+    end
+  end
+
+  desc 'List current releases'
+  task :list_releases do
+    on roles(:app) do
+      execute "ls -alt #{fetch(:deploy_to)}/releases"
     end
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,19 +66,6 @@ namespace :boston_library do
     end
   end
 
-  # rubocop:disable Layout/LineLength
-  desc 'Run a console command to test -rails console-'
-  task :rails_console_runner do
-    on roles(:app), in: :sequence, wait: 5 do
-      as fetch(:user) do
-        within release_path do
-          puts capture("cd #{release_path}; #{fetch(:rvm_installed)} #{fetch(:rvm_ruby_version)} do #{release_path}/bin/rails runner -e staging \"puts 'rails console works'\"")
-        end
-      end
-    end
-  end
-  # rubocop:enable Layout/LineLength
-
   desc 'Copy Gemfile and Gemfile.lock to shared directory'
   task :upload_gemfile do
     on roles(:app) do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -66,7 +66,6 @@ namespace :boston_library do
     end
   end
 
-
   # rubocop:disable Layout/LineLength
   desc 'Run a console command to test -rails console-'
   task :rails_console_runner do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -98,5 +98,6 @@ after :'boston_library:install_bundler', :'bundler:config'
 after :'bundler:config', :'bundler:install'
 before :'deploy:cleanup', :'boston_library:upload_gemfile'
 after :'deploy:cleanup', :'boston_library:update_service_ruby'
-after :'boston_library:update_service_ruby', :"boston_library:restart_#{fetch(:application)}_puma"
-after :"boston_library:restart_#{fetch(:application)}_puma", :'boston_library:restart_nginx'
+# after :'boston_library:update_service_ruby', :"boston_library:restart_#{fetch(:application)}_puma"
+# after :"boston_library:restart_#{fetch(:application)}_puma", :'boston_library:restart_nginx'
+after :'boston_library:update_service_ruby', :'boston_library:list_releases'


### PR DESCRIPTION
add "list_release" method in order to be easy to get the release version to be rolled back.