### PR TITLE
Puma and other sec updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 6.1.7.10'
 gem 'pg', '>= 0.18', '< 2.0'
 
 # Use Puma as the app server
-gem 'puma', '~> 5.6.9'
+gem 'puma', '~> 7.2'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
@@ -41,8 +41,6 @@ gem 'rack-attack', '~> 6.6'
 
 gem 'sprockets-rails', '~> 3.4'
 
-gem 'sd_notify', group: [:production, :staging]
-
 gem 'postmark-rails', '~> 0.22'
 
 # use redis for session_store in staging and production
@@ -50,7 +48,6 @@ gem 'redis', '~> 5.0'
 gem 'redis-actionpack', '~> 5.4'
 
 group :development, :test do
-  gem 'awesome_print'
   gem 'capistrano', '~> 3.19.2', require: false
   gem 'capistrano-rails', '~> 1.4', require: false
   gem 'capistrano-rvm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,6 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
-    awesome_print (1.9.2)
     base64 (0.2.0)
     bcrypt (3.1.22)
     blacklight (7.19.2)
@@ -166,7 +165,7 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
-    date (3.4.1)
+    date (3.5.1)
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -191,11 +190,11 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     execjs (2.9.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
@@ -235,7 +234,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.7.1)
+    json (2.19.8)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -273,7 +272,7 @@ GEM
     minitest (5.25.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.7)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -287,7 +286,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     net-ssh (7.3.0)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
@@ -322,7 +321,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (6.0.2)
-    puma (5.6.9)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
@@ -460,7 +459,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sd_notify (0.1.1)
     selenium-webdriver (4.18.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -494,7 +492,7 @@ GEM
       tins (~> 1.0)
     thor (1.4.0)
     tilt (2.4.0)
-    timeout (0.4.3)
+    timeout (0.6.1)
     tins (1.32.1)
       sync
     turbolinks (5.2.1)
@@ -541,7 +539,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  awesome_print
   bootstrap (~> 4.6)
   bpluser (~> 0.5)
   capistrano (~> 3.19.2)
@@ -558,7 +555,7 @@ DEPENDENCIES
   net-http
   pg (>= 0.18, < 2.0)
   postmark-rails (~> 0.22)
-  puma (~> 5.6.9)
+  puma (~> 7.2)
   rack-attack (~> 6.6)
   rails (~> 6.1.7.10)
   rails-controller-testing
@@ -570,7 +567,6 @@ DEPENDENCIES
   rubocop-rails (~> 2.16)
   rubocop-rspec (~> 2.16)
   sass-rails (>= 6)
-  sd_notify
   selenium-webdriver (~> 4.10)
   sprockets-rails (~> 3.4)
   sqlite3 (~> 1.4)
@@ -582,4 +578,4 @@ RUBY VERSION
    ruby 3.1.7p261
 
 BUNDLED WITH
-   2.6.8
+   2.6.9

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,7 +7,7 @@
 # and maximum; this matches the default thread size of Active Record.
 #
 rails_env = ENV.fetch('RAILS_ENV') { 'development' }
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 3 }
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 app_dir = File.expand_path('..', __dir__)
 
@@ -16,30 +16,25 @@ workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 
 environment rails_env
 
-worker_timeout 3600 if rails_env == 'development'
+worker_timeout rails_env == 'development' ? 3600 : 60
 
 preload_app!
 # New feature that reduces latency https://github.com/puma/puma/blob/master/5.0-Upgrade.md#lower-latency-better-throughput
 wait_for_less_busy_worker 0.002
 
-# New feature that runs garbage collector when forking workers https://github.com/puma/puma/blob/master/5.0-Upgrade.md#nakayoshi_fork
-nakayoshi_fork
-
-on_restart do
+before_restart do
    puts "Refreshing Gemfile at #{app_dir}/Gemfile"
    ENV['BUNDLE_GEMFILE'] = "#{app_dir}/Gemfile"
 end
 
 # Best Practice is to reconnect any Non Active Record Connections on boot in clustered mode
-on_worker_boot do
-  puts 'Extablishing Active Record Connection...'
-  ActiveSupport.on_load(:active_record) do
-    ActiveRecord::Base.establish_connection
-  end
+before_worker_boot do
+  puts 'Establishing Active Record Connection...'
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 end
 
 before_fork do
-  ActiveRecord::Base.connection_pool.disconnect!
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
 end
 
 if %w(staging production).member?(rails_env)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'awesome_print'
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
- Updated puma to `7.2.1`

- Updated `puma` config to prevent breaking changes introduced in version > 7

- Removed `nayoshi_fork` as that was removed in version 6

- Removed `sd_notify` since its not required for puma > 6

- Removed `awesome_print` 

- Updated `net-imap` to latest available patched version for to resolve CVE

- Updated `faraday` to latest available patched version to resolve CVE

- Updated `bundler` to the latest available version